### PR TITLE
Add `usesCleartextTraffic` support to manifest

### DIFF
--- a/apk/src/manifest.rs
+++ b/apk/src/manifest.rs
@@ -73,6 +73,8 @@ pub struct Application {
     pub icon: Option<String>,
     #[serde(rename(serialize = "android:label"))]
     pub label: Option<String>,
+    #[serde(rename(serialize = "android:usesCleartextTraffic"))]
+    pub uses_cleartext_traffic: Option<bool>,
     #[serde(rename(serialize = "android:appComponentFactory"))]
     pub app_component_factory: Option<String>,
     #[serde(rename(serialize = "meta-data"))]


### PR DESCRIPTION
Small change that adds clear text traffic support to the manifest. This is needed by evolve as we're using HTTP for authentication in our web view.