### PR TITLE
Revert breaking change

### DIFF
--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -465,7 +465,7 @@ impl CargoBuild {
     }
 
     pub fn set_sysroot(&mut self, path: &Path) {
-        let arg = format!("--sysroot=\"{}\"", path.display());
+        let arg = format!("--sysroot={}", path.display());
         self.add_cflag(&arg);
         self.add_link_arg(&arg);
     }


### PR DESCRIPTION
Reverts a line from https://github.com/Traverse-Research/xbuild/pull/3 that resulted in xbuild no longer working for some users. (see https://github.com/Traverse-Research/evolve/issues/568).
