### PR TITLE
add profile support

### DIFF
--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -264,7 +264,11 @@ impl CargoBuild {
         cmd.current_dir(root_dir);
         cmd.arg("build");
         cmd.arg("--target-dir").arg(target_dir);
-        if target.opt() == Opt::Release {
+
+        if let Opt::Profile(profile) = target.opt() {
+            cmd.arg("--profile");
+            cmd.arg(profile);
+        } else if *target.opt() == Opt::Release {
             cmd.arg("--release");
         }
         if let Some(triple) = triple.as_ref() {

--- a/xbuild/src/cargo/mod.rs
+++ b/xbuild/src/cargo/mod.rs
@@ -167,7 +167,7 @@ impl Cargo {
     pub fn artifact(
         &self,
         target_dir: &Path,
-        target: CompileTarget,
+        target: &CompileTarget,
         artifact: Option<Artifact>,
         ty: CrateType,
     ) -> Result<PathBuf> {
@@ -193,7 +193,7 @@ impl Cargo {
     pub fn lib_search_paths(
         &self,
         target_dir: &Path,
-        target: CompileTarget,
+        target: &CompileTarget,
     ) -> Result<Vec<PathBuf>> {
         let arch_dir = if target.is_host()? {
             target_dir.to_path_buf()

--- a/xbuild/src/command/build.rs
+++ b/xbuild/src/command/build.rs
@@ -310,7 +310,7 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                     let mut msix = Msix::new(
                         out,
                         env.config().windows().manifest.clone(),
-                        target.opt() != Opt::Debug,
+                        *target.opt() != Opt::Debug,
                     )?;
                     if let Some(icon) = env.icon() {
                         dbg!(icon);

--- a/xbuild/src/command/build.rs
+++ b/xbuild/src/command/build.rs
@@ -61,11 +61,12 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                 appimage.add_icon(icon)?;
             }
 
-            let main = env.cargo_artefact(&arch_dir.join("cargo"), target, CrateType::Bin)?;
+            let main = env.cargo_artefact(&arch_dir.join("cargo"), &target, CrateType::Bin)?;
             appimage.add_file(&main, Path::new(env.name()))?;
 
             if has_lib {
-                let lib = env.cargo_artefact(&arch_dir.join("cargo"), target, CrateType::Cdylib)?;
+                let lib =
+                    env.cargo_artefact(&arch_dir.join("cargo"), &target, CrateType::Cdylib)?;
                 appimage.add_file(&lib, &Path::new("lib").join(lib.file_name().unwrap()))?;
             }
 
@@ -83,7 +84,7 @@ pub fn build(env: &BuildEnv) -> Result<()> {
             for target in env.target().compile_targets() {
                 let arch_dir = platform_dir.join(target.arch().to_string());
                 let cargo_dir = arch_dir.join("cargo");
-                let lib = env.cargo_artefact(&cargo_dir, target, CrateType::Cdylib)?;
+                let lib = env.cargo_artefact(&cargo_dir, &target, CrateType::Cdylib)?;
 
                 let ndk = env.android_ndk();
 
@@ -99,7 +100,7 @@ pub fn build(env: &BuildEnv) -> Result<()> {
 
                 let mut search_paths = env
                     .cargo()
-                    .lib_search_paths(&cargo_dir, target)
+                    .lib_search_paths(&cargo_dir, &target)
                     .with_context(|| {
                         format!(
                             "Finding libraries in `{}` for {:?}",
@@ -203,7 +204,7 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                 let mut apk = Apk::new(
                     out,
                     env.config().android().manifest.clone(),
-                    env.target().opt() != Opt::Debug,
+                    *env.target().opt() != Opt::Debug,
                 )?;
                 apk.add_res(env.icon(), &env.android_jar())?;
 
@@ -242,11 +243,12 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                 app.add_icon(icon)?;
             }
 
-            let main = env.cargo_artefact(&arch_dir.join("cargo"), target, CrateType::Bin)?;
+            let main = env.cargo_artefact(&arch_dir.join("cargo"), &target, CrateType::Bin)?;
             app.add_executable(&main)?;
 
             if has_lib {
-                let lib = env.cargo_artefact(&arch_dir.join("cargo"), target, CrateType::Cdylib)?;
+                let lib =
+                    env.cargo_artefact(&arch_dir.join("cargo"), &target, CrateType::Cdylib)?;
                 app.add_lib(&lib)?;
             }
 
@@ -273,7 +275,7 @@ pub fn build(env: &BuildEnv) -> Result<()> {
             if let Some(icon) = env.icon() {
                 app.add_icon(icon)?;
             }
-            let main = env.cargo_artefact(&arch_dir.join("cargo"), target, CrateType::Bin)?;
+            let main = env.cargo_artefact(&arch_dir.join("cargo"), &target, CrateType::Bin)?;
             app.add_executable(&main)?;
             if let Some(provisioning_profile) = env.target().provisioning_profile() {
                 app.add_provisioning_profile(provisioning_profile)?;
@@ -299,7 +301,7 @@ pub fn build(env: &BuildEnv) -> Result<()> {
             let arch_dir = platform_dir.join(target.arch().to_string());
             std::fs::create_dir_all(&arch_dir)?;
             let out = arch_dir.join(format!("{}.{}", env.name(), env.target().format()));
-            let main = env.cargo_artefact(&arch_dir.join("cargo"), target, CrateType::Bin)?;
+            let main = env.cargo_artefact(&arch_dir.join("cargo"), &target, CrateType::Bin)?;
             match env.target().format() {
                 Format::Exe => {
                     std::fs::copy(&main, &out)?;
@@ -328,8 +330,11 @@ pub fn build(env: &BuildEnv) -> Result<()> {
 
                     // TODO: Investigate use-cases for `.dll`s in MSIX (Rust compiles static self-contained binaries)
                     if has_lib {
-                        match env.cargo_artefact(&arch_dir.join("cargo"), target, CrateType::Cdylib)
-                        {
+                        match env.cargo_artefact(
+                            &arch_dir.join("cargo"),
+                            &target,
+                            CrateType::Cdylib,
+                        ) {
                             Ok(lib) => msix.add_file(
                                 &lib,
                                 Path::new(lib.file_name().unwrap()),

--- a/xbuild/src/command/mod.rs
+++ b/xbuild/src/command/mod.rs
@@ -38,7 +38,11 @@ pub fn run(env: &BuildEnv) -> Result<()> {
 
 pub fn lldb(env: &BuildEnv) -> Result<()> {
     if let Some(device) = env.target().device() {
-        let target = CompileTarget::new(device.platform()?, device.arch()?, env.target().opt());
+        let target = CompileTarget::new(
+            device.platform()?,
+            device.arch()?,
+            env.target().opt().clone(),
+        );
         let cargo_dir = env
             .build_dir()
             .join(target.opt().to_string())
@@ -46,7 +50,7 @@ pub fn lldb(env: &BuildEnv) -> Result<()> {
             .join(target.arch().to_string())
             .join("cargo");
         let executable = match target.platform() {
-            Platform::Android => env.cargo_artefact(&cargo_dir, target, CrateType::Cdylib)?,
+            Platform::Android => env.cargo_artefact(&cargo_dir, &target, CrateType::Cdylib)?,
             Platform::Ios => env.output(),
             Platform::Linux => env.output().join(env.name()),
             Platform::Macos => env.executable(),

--- a/xbuild/src/config.rs
+++ b/xbuild/src/config.rs
@@ -80,7 +80,7 @@ impl Config {
         &mut self,
         manifest_package: &Package,
         workspace_manifest: Option<&Manifest>,
-        opt: Opt,
+        opt: &Opt,
     ) -> Result<()> {
         // android
         let wry = self.android.wry;
@@ -166,7 +166,7 @@ impl Config {
         }
         application
             .debuggable
-            .get_or_insert_with(|| opt == Opt::Debug);
+            .get_or_insert_with(|| *opt == Opt::Debug);
 
         application
             .has_code

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -287,8 +287,8 @@ impl CompileTarget {
         self.arch
     }
 
-    pub fn opt(&self) -> Opt {
-        self.opt.clone()
+    pub fn opt(&self) -> &Opt {
+        &self.opt
     }
 
     pub fn android_abi(&self) -> apk::Target {


### PR DESCRIPTION
Allows for specifying a custom cargo profile besides `--release` and `--debug`. 