### PR TITLE
🆙 Update download ORG and VERSION

### DIFF
--- a/xbuild/Cargo.toml
+++ b/xbuild/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xbuild"
-version = "0.2.0"
+version = "0.2.0+traverse"
 edition = "2021"
 description = "Builds rust mobile/desktop projects."
 repository = "https://github.com/rust-mobile/xbuild"

--- a/xbuild/src/download.rs
+++ b/xbuild/src/download.rs
@@ -191,9 +191,9 @@ impl WorkItem {
 }
 
 impl WorkItem {
-    const ORG: &'static str = "rust-mobile";
+    const ORG: &'static str = "Traverse-Research";
     const REPO: &'static str = "xbuild";
-    const VERSION: &'static str = "v0.1.0+3";
+    const VERSION: &'static str = "v0.2.0+traverse";
 
     pub fn xbuild_release(output: PathBuf, artifact: &str) -> Self {
         Self::github_release(output, Self::ORG, Self::REPO, Self::VERSION, artifact)


### PR DESCRIPTION
To update the SDK to the latest version (now at 35), we will need to create a release and update our download URL. This PR does the first step by updating the xbuild version and download path. Once this PR lands we will do a release.