### PR TITLE
🚓 Update CI references and Android paths

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -29,7 +29,7 @@ jobs:
     - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/i686-linux-android/libgcc.a
 
     - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
-    - run: gh release upload $TAG Android.ndk.tar.zst -R rust-mobile/xbuild
+    - run: gh release upload $TAG Android.ndk.tar.zst -R Traverse-Research/xbuild
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.event.release.tag_name }}
@@ -42,7 +42,7 @@ jobs:
       env:
         SDK_PATH: /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
     - run: gtar --zstd -cf MacOSX.sdk.tar.zst MacOSX.sdk
-    - run: gh release upload $TAG MacOSX.sdk.tar.zst -R rust-mobile/xbuild
+    - run: gh release upload $TAG MacOSX.sdk.tar.zst -R Traverse-Research/xbuild
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.event.release.tag_name }}
@@ -55,7 +55,7 @@ jobs:
       env:
         SDK_PATH: /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
     - run: gtar --zstd -cf iPhoneOS.sdk.tar.zst iPhoneOS.sdk
-    - run: gh release upload $TAG iPhoneOS.sdk.tar.zst -R rust-mobile/xbuild
+    - run: gh release upload $TAG iPhoneOS.sdk.tar.zst -R Traverse-Research/xbuild
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.event.release.tag_name }}
@@ -68,7 +68,7 @@ jobs:
     - run: cargo install xwin
     - run: xwin --accept-license splat --output Windows.sdk
     - run: tar --zstd -cf Windows.sdk.tar.zst Windows.sdk
-    - run: gh release upload $TAG Windows.sdk.tar.zst -R rust-mobile/xbuild
+    - run: gh release upload $TAG Windows.sdk.tar.zst -R Traverse-Research/xbuild
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: |
+        # ANDROID_NDK_LATEST_HOME is defined in the github ubuntu-latest runner. If this needs to be installed on a different image
+        # this can be done by running `sdkmanager "ndk;VERSION"` and setting `ANDROID_NDK_LATEST_HOME` to `$ANDROID_HOME/ndk/VERSION`.
         TOOLCHAIN="$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64"
         CLANG_VERSION="$(ls $TOOLCHAIN/lib/clang)"
         CLANG="$TOOLCHAIN/lib/clang/$CLANG_VERSION"

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -9,25 +9,26 @@ jobs:
   android:
     runs-on: ubuntu-latest
     steps:
-    - run: echo "TOOLCHAIN=$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64" >> $GITHUB_ENV
-    - run: ls $TOOLCHAIN/lib64/clang | xargs -0 printf "CLANG_VERSION=%s" >> $GITHUB_ENV
-    - run: echo "CLANG=$TOOLCHAIN/lib64/clang/$CLANG_VERSION" >> $GITHUB_ENV
+    - run: |
+        TOOLCHAIN="$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64"
+        CLANG_VERSION="$(ls $TOOLCHAIN/lib/clang)"
+        CLANG="$TOOLCHAIN/lib/clang/$CLANG_VERSION"
 
-    - run: echo $ANDROID_NDK_LATEST_HOME
-    - run: echo $CLANG_VERSION
+        echo "ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME"
+        echo "CLANG_VERSION=$CLANG_VERSION"
 
-    - run: mkdir Android.ndk
-    - run: cp -r $TOOLCHAIN/sysroot/usr Android.ndk/
-    - run: cp -r $CLANG/lib/linux/aarch64/* Android.ndk/usr/lib/aarch64-linux-android/
-    - run: cp -r $CLANG/lib/linux/arm/* Android.ndk/usr/lib/arm-linux-androideabi/
-    - run: cp -r $CLANG/lib/linux/x86_64/* Android.ndk/usr/lib/x86_64-linux-android/
-    - run: cp -r $CLANG/lib/linux/i386/* Android.ndk/usr/lib/i686-linux-android/
+        mkdir -p Android.ndk && cd Android.ndk
 
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/aarch64-linux-android/libgcc.a
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/arm-linux-androideabi/libgcc.a
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/x86_64-linux-android/libgcc.a
-    - run: echo "INPUT(-lunwind)" > Android.ndk/usr/lib/i686-linux-android/libgcc.a
+        cp -r "$TOOLCHAIN/sysroot/usr"     ./usr
+        cp -r "$CLANG/lib/linux/aarch64/*" ./usr/lib/aarch64-linux-android/
+        cp -r "$CLANG/lib/linux/arm/*"     ./usr/lib/arm-linux-androideabi/
+        cp -r "$CLANG/lib/linux/x86_64/*"  ./usr/lib/x86_64-linux-android/
+        cp -r "$CLANG/lib/linux/i386/*"    ./usr/lib/i686-linux-android/
 
+        echo "INPUT(-lunwind)" > ./usr/lib/aarch64-linux-android/libgcc.a
+        echo "INPUT(-lunwind)" > ./usr/lib/arm-linux-androideabi/libgcc.a
+        echo "INPUT(-lunwind)" > ./usr/lib/x86_64-linux-android/libgcc.a
+        echo "INPUT(-lunwind)" > ./usr/lib/i686-linux-android/libgcc.a
     - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
     - run: gh release upload $TAG Android.ndk.tar.zst -R Traverse-Research/xbuild
       env:


### PR DESCRIPTION
In #9 we bumped the initial requirements to do an release, but some aspects of the sdk release workflow are outdated. This PR updates the workflow and makes it a bit easier to read. I validated the android and windows paths, but cannot do so for the macos paths. If these fail we can do another update on them later.