### PR TITLE
Use `XBUILD_SECRET` in CI 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - run: mv bin/x xbuild-linux-x64
     - run: gh release upload $TAG xbuild-linux-x64 -R rust-mobile/xbuild
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}
         TAG: ${{ github.event.release.tag_name }}
 
   macos:
@@ -31,7 +31,7 @@ jobs:
     - run: mv bin/x xbuild-macos-x64
     - run: gh release upload $TAG xbuild-macos-x64 -R rust-mobile/xbuild
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}
         TAG: ${{ github.event.release.tag_name }}
 
   windows:
@@ -43,5 +43,5 @@ jobs:
     - run: mv bin/x.exe xbuild-windows-x64.exe
     - run: gh release upload $TAG xbuild-windows-x64.exe -R rust-mobile/xbuild
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}
         TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -34,7 +34,7 @@ jobs:
     - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
     - run: gh release upload $TAG Android.ndk.tar.zst -R Traverse-Research/xbuild
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}
         TAG: ${{ github.event.release.tag_name }}
 
   macos:
@@ -47,7 +47,7 @@ jobs:
     - run: gtar --zstd -cf MacOSX.sdk.tar.zst MacOSX.sdk
     - run: gh release upload $TAG MacOSX.sdk.tar.zst -R Traverse-Research/xbuild
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}
         TAG: ${{ github.event.release.tag_name }}
 
   ios:
@@ -60,7 +60,7 @@ jobs:
     - run: gtar --zstd -cf iPhoneOS.sdk.tar.zst iPhoneOS.sdk
     - run: gh release upload $TAG iPhoneOS.sdk.tar.zst -R Traverse-Research/xbuild
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}
         TAG: ${{ github.event.release.tag_name }}
 
   windows:
@@ -73,5 +73,5 @@ jobs:
     - run: tar --zstd -cf Windows.sdk.tar.zst Windows.sdk
     - run: gh release upload $TAG Windows.sdk.tar.zst -R Traverse-Research/xbuild
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}
         TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Needed so that CI can use the GitHub CLI to upload tags to the repository.