### PR TITLE
Specify NDK version

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -21,7 +21,7 @@ jobs:
         echo "ANDROID_NDK_VERSION=$NDK_VERSION"
         echo "CLANG_VERSION=$CLANG_VERSION"
 
-        mkdir -p Android.ndk/$NDK_VERSION && cd Android.ndk/$NDK_VERSION
+        mkdir -p $NDK_VERSION && cd $NDK_VERSION
 
         cp -r $TOOLCHAIN/sysroot/usr    ./usr
         cp -r $CLANG/lib/linux/aarch64/* ./usr/lib/aarch64-linux-android/
@@ -33,7 +33,7 @@ jobs:
         echo "INPUT(-lunwind)" > ./usr/lib/arm-linux-androideabi/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/x86_64-linux-android/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/i686-linux-android/libgcc.a
-    - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
+    - run: tar --zstd -cf Android.ndk.tar.zst $NDK_VERSION
     - run: gh release upload $TAG Android.ndk.tar.zst -R Traverse-Research/xbuild
       env:
         GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -21,7 +21,7 @@ jobs:
         echo "ANDROID_NDK_VERSION=$NDK_VERSION"
         echo "CLANG_VERSION=$CLANG_VERSION"
 
-        mkdir -p Android.ndk/$NDK_VERSION && cd Android.ndk/$NDK_VERSION 
+        mkdir -p $NDK_VERSION && cd $NDK_VERSION 
 
         cp -r $TOOLCHAIN/sysroot/usr    ./usr
         cp -r $CLANG/lib/linux/aarch64/* ./usr/lib/aarch64-linux-android/
@@ -33,7 +33,9 @@ jobs:
         echo "INPUT(-lunwind)" > ./usr/lib/arm-linux-androideabi/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/x86_64-linux-android/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/i686-linux-android/libgcc.a
-    - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
+    - run: |
+        NDK_VERSION=$(basename $ANDROID_NDK_LATEST_HOME)
+        tar --zstd -cf Android.ndk.tar.zst $NDK_VERSION
     - run: gh release upload $TAG Android.ndk.tar.zst -R Traverse-Research/xbuild
       env:
         GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -18,10 +18,10 @@ jobs:
         NDK_VERSION=$(basename $ANDROID_NDK_LATEST_HOME)
 
         echo "ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME"
-        echo "ANDROID_NDK_VERSION=$NDK_VERSION"
+        echo "ANDROID_NDK_VERSION=$(basename $ANDROID_NDK_LATEST_HOME)"
         echo "CLANG_VERSION=$CLANG_VERSION"
 
-        mkdir -p $NDK_VERSION && cd $NDK_VERSION 
+        mkdir -p Android.ndk && cd Android.ndk
 
         cp -r $TOOLCHAIN/sysroot/usr    ./usr
         cp -r $CLANG/lib/linux/aarch64/* ./usr/lib/aarch64-linux-android/
@@ -33,9 +33,7 @@ jobs:
         echo "INPUT(-lunwind)" > ./usr/lib/arm-linux-androideabi/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/x86_64-linux-android/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/i686-linux-android/libgcc.a
-    - run: |
-        NDK_VERSION=$(basename $ANDROID_NDK_LATEST_HOME)
-        tar --zstd -cf Android.ndk.tar.zst $NDK_VERSION
+    - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
     - run: gh release upload $TAG Android.ndk.tar.zst -R Traverse-Research/xbuild
       env:
         GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -21,7 +21,7 @@ jobs:
         echo "ANDROID_NDK_VERSION=$NDK_VERSION"
         echo "CLANG_VERSION=$CLANG_VERSION"
 
-        mkdir -p $NDK_VERSION && cd $NDK_VERSION
+        mkdir -p Android.ndk/$NDK_VERSION && cd Android.ndk/$NDK_VERSION 
 
         cp -r $TOOLCHAIN/sysroot/usr    ./usr
         cp -r $CLANG/lib/linux/aarch64/* ./usr/lib/aarch64-linux-android/
@@ -33,7 +33,7 @@ jobs:
         echo "INPUT(-lunwind)" > ./usr/lib/arm-linux-androideabi/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/x86_64-linux-android/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/i686-linux-android/libgcc.a
-    - run: tar --zstd -cf Android.ndk.tar.zst $NDK_VERSION
+    - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
     - run: gh release upload $TAG Android.ndk.tar.zst -R Traverse-Research/xbuild
       env:
         GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -21,7 +21,7 @@ jobs:
         echo "ANDROID_NDK_VERSION=$NDK_VERSION"
         echo "CLANG_VERSION=$CLANG_VERSION"
 
-        mkdir -p $NDK_VERSION && cd $NDK_VERSION 
+        mkdir -p Android.ndk/$NDK_VERSION && cd Android.ndk/$NDK_VERSION 
 
         cp -r $TOOLCHAIN/sysroot/usr    ./usr
         cp -r $CLANG/lib/linux/aarch64/* ./usr/lib/aarch64-linux-android/
@@ -33,9 +33,7 @@ jobs:
         echo "INPUT(-lunwind)" > ./usr/lib/arm-linux-androideabi/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/x86_64-linux-android/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/i686-linux-android/libgcc.a
-    - run: |
-        NDK_VERSION=$(basename $ANDROID_NDK_LATEST_HOME)
-        tar --zstd -cf Android.ndk.tar.zst $NDK_VERSION
+    - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
     - run: gh release upload $TAG Android.ndk.tar.zst -R Traverse-Research/xbuild
       env:
         GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -18,10 +18,10 @@ jobs:
         NDK_VERSION=$(basename $ANDROID_NDK_LATEST_HOME)
 
         echo "ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME"
-        echo "ANDROID_NDK_VERSION=$(basename $ANDROID_NDK_LATEST_HOME)"
+        echo "ANDROID_NDK_VERSION=$NDK_VERSION"
         echo "CLANG_VERSION=$CLANG_VERSION"
 
-        mkdir -p Android.ndk && cd Android.ndk
+        mkdir -p $NDK_VERSION && cd $NDK_VERSION 
 
         cp -r $TOOLCHAIN/sysroot/usr    ./usr
         cp -r $CLANG/lib/linux/aarch64/* ./usr/lib/aarch64-linux-android/
@@ -33,7 +33,9 @@ jobs:
         echo "INPUT(-lunwind)" > ./usr/lib/arm-linux-androideabi/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/x86_64-linux-android/libgcc.a
         echo "INPUT(-lunwind)" > ./usr/lib/i686-linux-android/libgcc.a
-    - run: tar --zstd -cf Android.ndk.tar.zst Android.ndk
+    - run: |
+        NDK_VERSION=$(basename $ANDROID_NDK_LATEST_HOME)
+        tar --zstd -cf Android.ndk.tar.zst $NDK_VERSION
     - run: gh release upload $TAG Android.ndk.tar.zst -R Traverse-Research/xbuild
       env:
         GITHUB_TOKEN: ${{ secrets.XBUILD_SECRET }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -15,11 +15,13 @@ jobs:
         TOOLCHAIN="$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64"
         CLANG_VERSION="$(ls $TOOLCHAIN/lib/clang)"
         CLANG="$TOOLCHAIN/lib/clang/$CLANG_VERSION"
+        NDK_VERSION=$(basename $ANDROID_NDK_LATEST_HOME)
 
         echo "ANDROID_NDK_LATEST_HOME=$ANDROID_NDK_LATEST_HOME"
+        echo "ANDROID_NDK_VERSION=$NDK_VERSION"
         echo "CLANG_VERSION=$CLANG_VERSION"
 
-        mkdir -p Android.ndk && cd Android.ndk
+        mkdir -p Android.ndk/$NDK_VERSION && cd Android.ndk/$NDK_VERSION
 
         cp -r $TOOLCHAIN/sysroot/usr    ./usr
         cp -r $CLANG/lib/linux/aarch64/* ./usr/lib/aarch64-linux-android/

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -37,6 +37,14 @@ mod download;
 mod gradle;
 mod task;
 
+/// Current NDK version xbuild should use for Android.
+///
+/// If this version is not available on a users machine xbuild will download it
+/// from our releases: ['https://github.com/Traverse-Research/xbuild/releases'].
+///
+/// The actual version used is determined by whatever the "ubuntu-latest" image has installed.
+const ANDROID_NDK_CURRENT: &str = "27.1.12297006";
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Opt {
     Debug,
@@ -753,7 +761,9 @@ impl BuildEnv {
     }
 
     pub fn android_ndk(&self) -> PathBuf {
-        self.cache_dir().join("Android.ndk")
+        self.cache_dir()
+            .join("Android.ndk")
+            .join(ANDROID_NDK_CURRENT)
     }
 
     pub fn ios_sdk(&self) -> PathBuf {


### PR DESCRIPTION
With this change, whenever we release a new version, the uploaded NDK artifact will use its version as directory name. This allows us to check against that version locally on a users device and download the version if it isn't cached.