### PR TITLE
update android gradle plugin version

### DIFF
--- a/xbuild/src/gradle/build.gradle
+++ b/xbuild/src/gradle/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.0' apply false
-    id 'com.android.library' version '7.3.0' apply false
+    id 'com.android.application' version '8.1.0' apply false
+    id 'com.android.library' version '8.1.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
 }
 


### PR DESCRIPTION
Update Android Gradle plugin from 7.3.0 to 8.1.0 so that we can use Sdk version up to 34.

