### PR TITLE
Fix gradle output path for custom profile

### DIFF
--- a/xbuild/src/gradle/mod.rs
+++ b/xbuild/src/gradle/mod.rs
@@ -217,6 +217,7 @@ pub fn build(env: &BuildEnv, libraries: Vec<(Target, PathBuf)>, out: &Path) -> R
         Format::Apk => "assemble",
         _ => unreachable!(),
     });
+
     task::run(cmd, true)?;
     let output = gradle
         .join("app")
@@ -227,14 +228,22 @@ pub fn build(env: &BuildEnv, libraries: Vec<(Target, PathBuf)>, out: &Path) -> R
             Format::Apk => "apk",
             _ => unreachable!(),
         })
-        .join(opt.to_string())
-        .join(match (format, opt) {
-            (Format::Apk, Opt::Debug) => "app-debug.apk",
-            (Format::Apk, Opt::Release) => "app-release-unsigned.apk",
-            (Format::Aab, Opt::Debug) => "app-debug.aab",
-            (Format::Aab, Opt::Release) => "app-release.aab",
-            _ => unreachable!(),
+        .join(match opt {
+            Opt::Debug => "debug",
+            Opt::Release | Opt::Profile(_) => "release",
+        })
+        .join({
+            match (format, opt) {
+                (Format::Apk, Opt::Debug) => "app-debug.apk",
+                (Format::Apk, Opt::Release) | (Format::Apk, Opt::Profile(_)) => {
+                    "app-release-unsigned.apk"
+                }
+                (Format::Aab, Opt::Debug) => "app-debug.aab",
+                (Format::Aab, Opt::Release) | (Format::Aab, Opt::Profile(_)) => "app-release.aab",
+                _ => unreachable!(),
+            }
         });
+
     std::fs::copy(output, out)?;
     Ok(())
 }


### PR DESCRIPTION
In my previous changes that added custom build profiles through `cargo build --profile my_profile` I forgot to update gradle accordingly. I'm not entirely sure how gradle should react to a custom profile but it seems like we can just point it to the `release` directory and its all good ™️.