### PR TITLE
Add dexes to AAB

### DIFF
--- a/xbuild/src/gradle/mod.rs
+++ b/xbuild/src/gradle/mod.rs
@@ -67,6 +67,33 @@ pub fn build(env: &BuildEnv, libraries: Vec<(Target, PathBuf)>, out: &Path) -> R
         dependencies.push_str(&format!("implementation '{}'\n", dep));
     }
 
+    let mut dexes = String::new();
+    for dex in &env.config().android().dexes {
+        let mut path = env.cargo().package_root().join(dex);
+
+        path.pop();
+
+        let path = path.display().to_string().replace(r"\", r"/");
+
+        let external_lib = format!(r#"task.dexDirs.from("{path}")"#);
+        dexes.push_str(&external_lib);
+        dexes.push_str("\n");
+    }
+
+    let dexes = if !dexes.is_empty() {
+        format!(
+            r#"
+            afterEvaluate {{
+                tasks.named("mergeDexRelease").configure {{ task ->
+                    {dexes}
+                }}
+            }}
+        "#
+        )
+    } else {
+        String::new()
+    };
+
     let asset_packs = if config.assets.is_empty() {
         ""
     } else {
@@ -94,6 +121,8 @@ pub fn build(env: &BuildEnv, libraries: Vec<(Target, PathBuf)>, out: &Path) -> R
             dependencies {{
                 {dependencies}
             }}
+
+            {dexes}
         "#,
         package = package,
         target_sdk = target_sdk,

--- a/xbuild/src/gradle/mod.rs
+++ b/xbuild/src/gradle/mod.rs
@@ -71,6 +71,9 @@ pub fn build(env: &BuildEnv, libraries: Vec<(Target, PathBuf)>, out: &Path) -> R
     for dex in &env.config().android().dexes {
         let mut path = env.cargo().package_root().join(dex);
 
+        // Pop the filename and use the directory.
+        //
+        // This is needed as we must provide a directory to `DexMergingTask::dexDirs`
         path.pop();
 
         let path = path.display().to_string().replace(r"\", r"/");


### PR DESCRIPTION
Adds precompiled dex files to the AAB by adding the directories containing the precompiled dex files to the input of the `mergeDexRelease` gradle task. The `mergeDexRelease` gradle task takes a file collection called `dexDirs` as input. The files in that file collection will all be merged together into a single dex file which is then packaged into the AAB.