### PR TITLE
Use `--strip-debug`

### DIFF
--- a/xbuild/src/command/build.rs
+++ b/xbuild/src/command/build.rs
@@ -100,7 +100,7 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                     std::process::Command::new("strip")
                         // I'm told this should always be valid for Android, so use this as the target
                         .arg("--target=elf64-little")
-                        .arg("--strip-all")
+                        .arg("--strip-debug")
                         .arg(&lib)
                         .spawn()
                         .expect("Could not strip debug symbols from lib")


### PR DESCRIPTION
`--strip-all` is quite aggressive and is most likely stripping critical information that breaks our builds. For that reason, use `--strip-debug` as that is the only data that we want to have stripped.