### PR TITLE
Do strip all 🙃 

### DIFF
--- a/xbuild/src/command/build.rs
+++ b/xbuild/src/command/build.rs
@@ -98,8 +98,7 @@ pub fn build(env: &BuildEnv) -> Result<()> {
                         .expect("Could not copy lib before stripping its debug symbols");
 
                     std::process::Command::new("strip")
-                        // I'm told this should always be valid for Android, so use this as the target
-                        .arg("--strip-debug")
+                        .arg("--strip-all")
                         .arg(&lib)
                         .spawn()
                         .expect("Could not strip debug symbols from lib")


### PR DESCRIPTION
Turns out that we don't seem to strip enough data from the binary which results in us going over the 200MB data limit for google play console. In order to upload to the play console, strip as much information. 

Now that we no longer specify `--target=elf64-little` I think our core issue should still be resolved.