### PR TITLE
adb: Use current date/time instead of last `logcat` line for timestamp

### DIFF
--- a/xbuild/src/devices/adb.rs
+++ b/xbuild/src/devices/adb.rs
@@ -233,23 +233,20 @@ impl Adb {
         Ok(())
     }
 
-    fn logcat_last_timestamp(&self, device: &str) -> Result<String> {
+    /// Returns the current device date and time in logcat timestamp format
+    fn current_date_time(&self, device: &str) -> Result<String> {
         let output = self
             .shell(device, None)
-            .arg("logcat")
-            .arg("-v")
-            .arg("time")
-            .arg("-t")
-            .arg("1")
+            .arg("date")
+            .arg(&*shlex::try_quote("+%m-%d %T.000")?)
             .output()?;
         anyhow::ensure!(
             output.status.success(),
-            "adb logcat exited with code {:?}: {}",
+            "`adb shell date` exited with code {:?}: {}",
             output.status.code(),
             std::str::from_utf8(&output.stderr)?.trim()
         );
-        let line = std::str::from_utf8(&output.stdout)?.lines().nth(1).unwrap();
-        Ok(line[..18].to_string())
+        Ok(std::str::from_utf8(&output.stdout)?.trim().to_owned())
     }
 
     fn uidof(&self, device: &str, id: &str) -> Result<u32> {
@@ -280,12 +277,12 @@ impl Adb {
         Ok(uid.parse()?)
     }
 
-    fn logcat(&self, device: &str, uid: u32, last_timestamp: &str) -> Result<Logcat> {
+    fn logcat(&self, device: &str, uid: u32, since: &str) -> Result<Logcat> {
         let child = self
-            .shell(device, None)
+            .adb(device)
             .arg("logcat")
             .arg("-T")
-            .arg(format!("'{}'", last_timestamp))
+            .arg(since)
             .arg(format!("--uid={}", uid))
             .arg("-v")
             .arg("color")
@@ -399,10 +396,10 @@ impl Adb {
         }
         self.install(device, path)?;
         self.forward_reverse(device, debug_config)?;
-        let last_timestamp = self.logcat_last_timestamp(device)?;
+        let since = self.current_date_time(device)?;
         self.start(device, package, activity, launch_args)?;
         let uid = self.uidof(device, package)?;
-        let logcat = self.logcat(device, uid, &last_timestamp)?;
+        let logcat = self.logcat(device, uid, &since)?;
         for line in logcat {
             print!("{}", line);
         }


### PR DESCRIPTION
We have some phones, including the Vivo X90 Pro which return an empty string for `logcat -t 1`, resulting in an `unwrap()` crash before starting logging.  There doesn't appear to be any reason to check the time of the latest **random** (not even `--uid`-scoped) message in `logcat` as we can just read the current date and time as well.  We haven't started the app yet either way, and this timestamp is inevitably already going to be later than the most recent message.

Also remove some unnecessary shell escaping (which should have been done by `shlex` otherwise) by calling `adb logcat` rather than `adb shell logcat`.
