### PR TITLE
Add `--xmanifest-path` argument to specify a separate manifest file

### DIFF
--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -356,7 +356,7 @@ pub struct BuildArgs {
     cargo: CargoArgs,
     /// Path to a xbuild `manifest.yaml` to use for this build.
     #[clap(long)]
-    x_manifest_path: Option<std::path::PathBuf>,
+    xmanifest_path: Option<std::path::PathBuf>,
     /// Use verbose output
     #[clap(long, short)]
     verbose: bool,
@@ -649,7 +649,7 @@ impl BuildEnv {
         let build_dir = cargo.target_dir().join("x");
         let cache_dir = dirs::cache_dir().unwrap().join("x");
         let package = cargo.manifest().package.as_ref().unwrap(); // Caller should guarantee that this is a valid package
-        let manifest = if let Some(manifest) = args.x_manifest_path {
+        let manifest = if let Some(manifest) = args.xmanifest_path {
             manifest
         } else {
             cargo.package_root().join("manifest.yaml")

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -354,6 +354,9 @@ pub struct BuildArgs {
     build_target: BuildTargetArgs,
     #[clap(flatten)]
     cargo: CargoArgs,
+    /// Path to a xbuild `manifest.yaml` to use for this build.
+    #[clap(long)]
+    x_manifest_path: Option<std::path::PathBuf>,
     /// Use verbose output
     #[clap(long, short)]
     verbose: bool,
@@ -646,7 +649,11 @@ impl BuildEnv {
         let build_dir = cargo.target_dir().join("x");
         let cache_dir = dirs::cache_dir().unwrap().join("x");
         let package = cargo.manifest().package.as_ref().unwrap(); // Caller should guarantee that this is a valid package
-        let manifest = cargo.package_root().join("manifest.yaml");
+        let manifest = if let Some(manifest) = args.x_manifest_path {
+            manifest
+        } else {
+            cargo.package_root().join("manifest.yaml")
+        };
         let mut config = Config::parse(manifest)?;
         let build_target = args.build_target.build_target(&config)?;
         config.apply_rust_package(package, cargo.workspace_manifest(), build_target.opt())?;

--- a/xbuild/src/lib.rs
+++ b/xbuild/src/lib.rs
@@ -354,7 +354,7 @@ pub struct BuildArgs {
     build_target: BuildTargetArgs,
     #[clap(flatten)]
     cargo: CargoArgs,
-    /// Path to a xbuild `manifest.yaml` to use for this build.
+    /// Path to an xbuild manifest to use for this build, instead of the default `manifest.yaml` in the crate root of the currently selected package.
     #[clap(long)]
     xmanifest_path: Option<std::path::PathBuf>,
     /// Use verbose output


### PR DESCRIPTION
Allows a user of `xbuild` to specify a specific `manifest.yaml` to use when building. Useful for having a specific `manifest` for development and for release builds. 

Ideally we shouldn't introduce this kind of duplication. A better solution would be to make `xbuild` more configurable through a build script. For example, when including vulkan validation layers for a development build, one should be able to use `xbuild:include-library=path`. Some more design work needs to go into this so for now we'll stick with the duplicate manifest yaml

